### PR TITLE
Upgrade buble-loader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "author": "Jeffrey Way",
   "license": "MIT",
   "dependencies": {
-    "buble": "^0.7.0",
-    "buble-loader": "^0.2.1",
+    "buble": "^0.12.0",
+    "buble-loader": "^0.2.2",
     "underscore": "^1.8.3",
     "webpack": "^2.1.0-beta.15",
     "webpack-stream": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Jeffrey Way",
   "license": "MIT",
   "dependencies": {
-    "buble": "^0.12.3",
+    "buble": "^0.7.0",
     "buble-loader": "^0.2.1",
     "underscore": "^1.8.3",
     "webpack": "^2.1.0-beta.15",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Jeffrey Way",
   "license": "MIT",
   "dependencies": {
-    "buble": "^0.12.0",
+    "buble": "^0.12.3",
     "buble-loader": "^0.2.2",
     "underscore": "^1.8.3",
     "webpack": "^2.1.0-beta.15",


### PR DESCRIPTION
Hi Jeffrey,

With:

```
    "laravel-elixir": "^6.0.0-9",
    "laravel-elixir-vue": "^0.1.1",
    "laravel-elixir-webpack-official": "^1.0.1"
```

I'm getting:

`npm WARN buble-loader@0.2.1 requires a peer of buble@^0.7.0 but none was installed.`

Related to [this PR](https://github.com/laravel/elixir/pull/552) which has since been refactored when webpack was stripped out into its own module.

Thanks
