### PR TITLE
Fix config merging

### DIFF
--- a/src/WebpackTask.js
+++ b/src/WebpackTask.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import {extend} from 'lodash';
+import {mergeWith, isArray} from 'lodash';
 
 let gulpWebpack;
 
@@ -68,12 +68,17 @@ class WebpackTask extends Elixir.Task {
         let defaultConfig = {
             output: { filename: this.output.name }
         };
-
-        return extend(
+        
+        return mergeWith(
             defaultConfig,
             Elixir.webpack.config,
             this.userWebpackConfig,
-            this.options
+            this.options,
+            (objValue, srcValue) => {
+                if (isArray(objValue)) {
+                    return objValue.concat(srcValue);
+                }
+            }
         );
     }
 }


### PR DESCRIPTION
Currently module loaders defined via `Elixir.webpack.mergeConfig` will be overriden by loaders defined in `webpack.config.js` (loaders aren't append to existing loaders definition but loaders definition gets overwritten entirely). The pull requests fixes this issue.

**How to reproduce**

``` js
// gulpfile.js

const elixir = require('laravel-elixir');

Elixir.ready(function () {
  Elixir.webpack.mergeConfig({
    module: {
      loaders: [
        {
          test: /\.json$/,
          loader: 'json-loader'
        }
      ]
    }
  })
})
```

``` js
// webpack.config.js

module.exports = {
  module: {
    loaders: [
      {
        test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,
        loader: 'file-loader',
        query: {
          limit: 10000,
          name: '../img/[name].[hash:7].[ext]'
        }
      }
    ]
  }
}

```

**Expected Result**

The [final webpack config](https://github.com/JeffreyWay/laravel-elixir-webpack-official/blob/master/src/WebpackTask.js#L58) should contain at least two entries for the _loaders_ array.

**Actual Result**

The final config contains just the loaders entry of `webpack.config.js`. The one defined via `Elixir.webpack.mergeConfig` is missing.

**Fix**

See pull request. Just adapted merging of configs in [`WebpackTask.js`](https://github.com/JeffreyWay/laravel-elixir-webpack-official/blob/master/src/WebpackTask.js#L67) from [`index.js`](https://github.com/JeffreyWay/laravel-elixir-webpack-official/blob/master/src/index.js#L32)

**Real World Scenario**
- installing [laravel-elixir-vue-2](https://github.com/vuejs/laravel-elixir-vue-2) to get started with vue 2.0
- installing another package that requires to load json files (`json-loader`)
- adding `json-loader` as module loader to `webpack.config.js`
- result: webpack fails since module loader configuration defined by _laravel-elixir-vue-2_ using `Elixir.webpack.mergeConfig` gets overwritten by module loader configuration in `webpack.config.js`
