### PR TITLE
Update webpack dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "buble": "^0.12.3",
     "buble-loader": "^0.2.2",
     "lodash": "^4.15.0",
-    "webpack": "^2.1.0-beta.15",
+    "webpack": "2.1.0-beta.15 - 2.1.0-beta.22",
     "webpack-stream": "^3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is a temporary patch to prevent broken builds until the package is made compatible with the breaking changes introduced in webpack 2.1.0-beta.23. I'd just submit a patch to make it compatible but I haven't had time to look into what that would involve, so I'm submiting this for now.
