### PR TITLE
trailing comma breaking npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
-    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-es2015": "^6.9.0"
   }
 }


### PR DESCRIPTION
noticed latest version isn't on npm yet, i think this trailing comma was breaking it

https://cl.ly/3x2d121b2z19
