### PR TITLE
Pass only js files to minify (closes #27)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "buble": "^0.12.3",
     "buble-loader": "^0.2.2",
+    "gulp-filter": "^4.0.0",
     "lodash": "^4.15.0",
     "webpack": "2.1.0-beta.15 - 2.1.0-beta.22",
     "webpack-stream": "github:jeroennoten/webpack-stream#patch-1"

--- a/src/WebpackTask.js
+++ b/src/WebpackTask.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import {mergeWith, isArray} from 'lodash';
+import filter from 'gulp-filter';
 
 let gulpWebpack;
 
@@ -35,13 +36,16 @@ class WebpackTask extends Elixir.Task {
      * Build up the Gulp task.
      */
     gulpTask() {
+        const jsFiles = filter(['**/*.js'], {restore: true});
         return (
             gulp
             .src(this.src.path)
             .pipe(this.webpack())
             .on('error', this.onError())
+            .pipe(jsFiles)
             .pipe(this.minify())
             .on('error', this.onError())
+            .pipe(jsFiles.restore)
             .pipe(this.saveAs(gulp))
             .pipe(this.onSuccess())
         );


### PR DESCRIPTION
See #27 

Using `gulp-filter`, we can minify only the `.js` files in a straightforward way :smile:
