### PR TITLE
Exclude node_modules from Buble

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ Elixir.webpack = {
         },
         devtool: Elixir.config.sourcemaps ? 'eval-cheap-module-source-map' : '',
         module: {
-            loaders: [{ test: /\.js$/, loader: 'buble' }]
+            loaders: [{ test: /\.js$/, loader: 'buble', exclude: /node_modules/ }]
         },
         stats: {
             assets: false,


### PR DESCRIPTION
Libraries are supposed to publish the transpiled files. This PR should boost Webpack performance a bit!
